### PR TITLE
add GDDRAM preposition directive to monogl_canvas_draw_point

### DIFF
--- a/src/monogl_canvas.c
+++ b/src/monogl_canvas.c
@@ -67,17 +67,28 @@ void monogl_canvas_draw_point(const monogl_canvas_t *const canvas, uint16_t x, u
 
   uint8_t *base_ptr = (uint8_t *) canvas->points;
 
+#if defined(GDDRAM)
+  uint8_t *ptr = base_ptr + x + (y / 8u) * width;
+#else
   uint32_t offset = y * width + x;
-
   uint8_t *ptr = base_ptr + offset / 8u;
+#endif
 
   switch (color) {
     case MONOGL_COLOR_BLACK: {
+#if defined(GDDRAM)
+      *ptr |= 0x01u << (y & 7u);
+#else
       *ptr |= 0x80u >> (offset & 7u);
+#endif
       break;
     }
     case MONOGL_COLOR_WHITE: {
+#if defined(GDDRAM)
+      *ptr &= ~(0x01u << (y & 7u));
+#else
       *ptr &= ~(0x80u >> (offset & 7u));
+#endif
       break;
     }
   }


### PR DESCRIPTION
The `GDDRAM` is a bit mapped static RAM holding the bit pattern to be displayed. The size of the RAM is `width x height` bits and the RAM is divided into several pages, from `PAGE0` to `PAGEN`, which are used for monochrome `width x height` dot matrix display.