### PR TITLE
monogl_surface_t

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,8 @@ set(MONOGL_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 set(MONOGL_SOURCE_FILES
         ${MONOGL_SOURCE_DIR}/monogl_image.c
-        ${MONOGL_SOURCE_DIR}/monogl_canvas.c)
+        ${MONOGL_SOURCE_DIR}/monogl_canvas.c
+        ${MONOGL_SOURCE_DIR}/monogl_surface.c)
 
 add_library(monogl OBJECT
         ${MONOGL_SOURCE_FILES})

--- a/include/monogl/monogl_surface.h
+++ b/include/monogl/monogl_surface.h
@@ -1,0 +1,53 @@
+/*
+ * This file is part of the 'Yet another gauge' project.
+ *
+ * Copyright (C) 2018 Ivan Dyachenko <vandyachen@gmail.com>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef YET_ANOTHER_GAUGE__MONOGL__SURFACE_H
+#define YET_ANOTHER_GAUGE__MONOGL__SURFACE_H
+
+#include "monogl_types.h"
+
+/**
+ * @brief Allocate a struct monogl_surface_t, intended to be used as a surface
+ * @param [in] width Number of dots in each row
+ * @param [in] height Number of dots in each column
+ * @return Created monogl_surface_t
+ */
+MONOGL_API monogl_surface_t *monogl_surface_new(uint16_t width, uint16_t height);
+
+/**
+ * @brief Free the memory for the given surface
+ * @param [in,out] surface
+ */
+MONOGL_API void monogl_surface_delete(monogl_surface_t *);
+
+/**
+ * @brief Return canvas that draws into surface
+ * @param [in] surface
+ * @return The canvas
+ */
+MONOGL_API monogl_canvas_t *monogl_surface_get_canvas(const monogl_surface_t *const);
+
+/**
+ * @brief Return pointer to dots buffer
+ * @param [in] surface
+ * @return Pointer to dots buffer
+ */
+MONOGL_API void *monogl_surface_get_dots(const monogl_surface_t *const);
+
+#endif // YET_ANOTHER_GAUGE__MONOGL__SURFACE_H

--- a/include/monogl/monogl_types.h
+++ b/include/monogl/monogl_types.h
@@ -36,7 +36,7 @@ typedef enum {
 } monogl_color_t;
 
 /**
- * @brief Describes a two dimensional array of points/pixels to draw
+ * @brief Describes a two dimensional array of dots to draw
  */
 typedef struct monogl_image_t monogl_image_t;
 
@@ -44,5 +44,10 @@ typedef struct monogl_image_t monogl_image_t;
  * @brief Provides an interface for drawing
  */
 typedef struct monogl_canvas_t monogl_canvas_t;
+
+/**
+ * @brief Responsible for managing the dots that a canvas draws into
+ */
+typedef struct monogl_surface_t monogl_surface_t;
 
 #endif // YET_ANOTHER_GAUGE__MONOGL__TYPES_H

--- a/src/monogl_surface.c
+++ b/src/monogl_surface.c
@@ -1,0 +1,65 @@
+/*
+ * This file is part of the 'Yet another gauge' project.
+ *
+ * Copyright (C) 2018 Ivan Dyachenko <vandyachen@gmail.com>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdlib.h>
+
+#include "monogl/monogl_canvas.h"
+#include "monogl/monogl_surface.h"
+
+struct monogl_surface_t {
+  void *dots;
+  size_t byte_size;
+
+  monogl_canvas_t *canvas;
+};
+
+monogl_surface_t *monogl_surface_new(uint16_t width, uint16_t height) {
+  monogl_surface_t *surface = malloc(sizeof(monogl_surface_t));
+
+#if defined(GDDRAM)
+  size_t byte_size = width * ((height + 7u) / 8u);
+#else
+  size_t byte_size = (width * height + 7u) / 8u;
+#endif
+
+  void *dots = malloc(byte_size);
+  surface->dots = dots;
+  surface->byte_size = byte_size;
+
+  surface->canvas = monogl_canvas_new(width, height, dots, byte_size);
+
+  return surface;
+}
+
+void monogl_surface_delete(monogl_surface_t *surface) {
+  if (surface != NULL) {
+    monogl_canvas_delete(surface->canvas);
+
+    free(surface->dots);
+    free(surface);
+  }
+}
+
+monogl_canvas_t *monogl_surface_get_canvas(const monogl_surface_t *const surface) {
+  return surface->canvas;
+}
+
+void *monogl_surface_get_dots(const monogl_surface_t *const surface) {
+  return surface->dots;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,7 +24,8 @@ set(CMAKE_C_FLAGS "-v ${CMAKE_C_FLAGS}")
 set(TEST_SOURCES
         test_monogl.c
         test_monogl_image.c
-        test_monogl_canvas.c)
+        test_monogl_canvas.c
+        test_monogl_surface.c)
 
 add_executable(test_monogl
         ${TEST_SOURCES}

--- a/tests/test_monogl.c
+++ b/tests/test_monogl.c
@@ -32,6 +32,11 @@ void test_monogl_canvas_draw_dot(void);
 void test_monogl_canvas_draw_rect(void);
 void test_monogl_canvas_draw_image(void);
 
+void test_monogl_surface_new(void);
+void test_monogl_surface_delete(void);
+void test_monogl_surface_get_canvas(void);
+void test_monogl_surface_get_dots(void);
+
 int main(void) {
   UNITY_BEGIN();
 
@@ -47,6 +52,11 @@ int main(void) {
   RUN_TEST(test_monogl_canvas_draw_dot);
   RUN_TEST(test_monogl_canvas_draw_rect);
   RUN_TEST(test_monogl_canvas_draw_image);
+
+  RUN_TEST(test_monogl_surface_new);
+  RUN_TEST(test_monogl_surface_delete);
+  RUN_TEST(test_monogl_surface_get_canvas);
+  RUN_TEST(test_monogl_surface_get_dots);
 
   return UNITY_END();
 }

--- a/tests/test_monogl_surface.c
+++ b/tests/test_monogl_surface.c
@@ -1,0 +1,91 @@
+/*
+ * This file is part of the 'Yet another gauge' project.
+ *
+ * Copyright (C) 2018 Ivan Dyachenko <vandyachen@gmail.com>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdlib.h>
+
+#include <unity.h>
+
+#include "../include/monogl/monogl_canvas.h"
+#include "../include/monogl/monogl_surface.h"
+
+void test_monogl_surface_new(void) {
+  uint16_t width = 132;
+  uint16_t height = 64;
+
+  monogl_surface_t *surface = monogl_surface_new(width, height);
+
+  TEST_ASSERT_NOT_NULL(surface);
+
+  monogl_surface_delete(surface);
+}
+
+void test_monogl_surface_delete(void) {
+  // todo
+}
+
+void test_monogl_surface_get_canvas(void) {
+  uint16_t width = 132;
+  uint16_t height = 64;
+
+  monogl_surface_t *surface = monogl_surface_new(width, height);
+  monogl_canvas_t *canvas = monogl_surface_get_canvas(surface);
+
+  TEST_ASSERT_NOT_NULL(canvas);
+
+  monogl_surface_delete(surface);
+}
+
+void test_monogl_surface_get_dots(void) {
+  uint16_t width = 3;
+  uint16_t height = 11;
+
+  monogl_surface_t *surface = monogl_surface_new(width, height);
+
+  void *dots = monogl_surface_get_dots(surface);
+  monogl_canvas_t *canvas = monogl_surface_get_canvas(surface);
+
+  monogl_canvas_clear(canvas);
+
+  monogl_canvas_draw_dot(canvas, 1, 0, MONOGL_COLOR_BLACK);
+  monogl_canvas_draw_dot(canvas, 0, 1, MONOGL_COLOR_BLACK);
+  monogl_canvas_draw_dot(canvas, 2, 1, MONOGL_COLOR_BLACK);
+  monogl_canvas_draw_dot(canvas, 0, 2, MONOGL_COLOR_BLACK);
+  monogl_canvas_draw_dot(canvas, 1, 2, MONOGL_COLOR_BLACK);
+  monogl_canvas_draw_dot(canvas, 2, 2, MONOGL_COLOR_BLACK);
+  monogl_canvas_draw_dot(canvas, 0, 4, MONOGL_COLOR_BLACK);
+  monogl_canvas_draw_dot(canvas, 1, 4, MONOGL_COLOR_BLACK);
+  monogl_canvas_draw_dot(canvas, 2, 4, MONOGL_COLOR_BLACK);
+  monogl_canvas_draw_dot(canvas, 0, 5, MONOGL_COLOR_BLACK);
+  monogl_canvas_draw_dot(canvas, 1, 6, MONOGL_COLOR_BLACK);
+  monogl_canvas_draw_dot(canvas, 2, 7, MONOGL_COLOR_BLACK);
+  monogl_canvas_draw_dot(canvas, 0, 8, MONOGL_COLOR_BLACK);
+  monogl_canvas_draw_dot(canvas, 1, 8, MONOGL_COLOR_BLACK);
+  monogl_canvas_draw_dot(canvas, 2, 8, MONOGL_COLOR_BLACK);
+  monogl_canvas_draw_dot(canvas, 0, 9, MONOGL_COLOR_BLACK);
+  monogl_canvas_draw_dot(canvas, 2, 9, MONOGL_COLOR_BLACK);
+  monogl_canvas_draw_dot(canvas, 1, 10, MONOGL_COLOR_BLACK);
+
+  size_t byte_size = (width * height + 7u) / 8u;
+  uint8_t expected[5] = {0b01010111, 0b10001111, 0b00010001, 0b11110101, 0b00000000};
+
+  TEST_ASSERT_NOT_NULL(dots);
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected, dots, byte_size);
+
+  monogl_surface_delete(surface);
+}


### PR DESCRIPTION
#7 [Implement monogl_surface_t](https://github.com/yet-another-gauge/monogl/issues/7):

#### monogl_types.h
```c
/**
 * @brief Responsible for managing the dots that a canvas draws into
 */
typedef struct monogl_surface_t monogl_surface_t;
```

#### monogl_surface.h
```c
/**
 * @brief Allocate a struct monogl_surface_t, intended to be used as a surface
 * @param [in] width Number of dots in each row
 * @param [in] height Number of dots in each column
 * @return Created monogl_surface_t
 */
MONOGL_API monogl_surface_t *monogl_surface_new(uint16_t width, uint16_t height);

/**
 * @brief Free the memory for the given surface
 * @param [in,out] surface
 */
MONOGL_API void monogl_surface_delete(monogl_surface_t *);

/**
 * @brief Return canvas that draws into surface
 * @param [in] surface
 * @return The canvas
 */
MONOGL_API monogl_canvas_t *monogl_surface_get_canvas(const monogl_surface_t *const);

/**
 * @brief Return pointer to dots buffer
 * @param [in] surface
 * @return Pointer to dots buffer
 */
MONOGL_API void *monogl_surface_get_dots(const monogl_surface_t *const);
```